### PR TITLE
Fix localised_name of generated technologies

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -43,7 +43,11 @@ for k, v in pairs(tools) do
 		if each_pack then
 			local technology = {};
 			technology.name = "Ket-IT-" .. k;
-			technology.localised_name = v.name;
+			local localised_name = v.localised_name;
+			if localised_name == nil then
+				localised_name = {"item-name." .. v.name};
+			end
+			technology.localised_name = {"", localised_name, " infinite"};
 			technology.type = "technology";
 			if v.icon ~= nil then
 				technology.icon = v.icon;


### PR DESCRIPTION
This adds nice names for all the generated science packs.  For example, instead of "automation-science-pack N", the name will now be "Automation science pack infinite N", using the localised name of the base science pack item with " infinite" appended.

Specifically, if the science pack's localised_name is set, then it will use that plus " infinite".  Otherwise, it will use the translated name of the item plus " infinite".

References:
- details on the format of LocalisedString: https://wiki.factorio.com/Tutorial:Localisation and https://lua-api.factorio.com/latest/concepts/LocalisedString.html